### PR TITLE
Dockerizing application 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.24 AS builder
+WORKDIR /app
+
+COPY . .
+RUN go mod download
+RUN go mod tidy
+
+WORKDIR /app
+RUN CGO_ENABLED=0 GOOS=linux go build -o tgnotify
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+COPY --from=builder /app/tgnotify .
+ENTRYPOINT [ "./tgnotify" ]

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,6 @@
 # TG Notify Service  
 
+## About
 This is a simple notification service (not a daemon) that sends notifications to Telegram at the end of a running command.  
 
 The service reads its configuration from the `NOTIFY_CONFIG` environment variable. If the variable is not set, the service stops and does not execute any commands. The command's output is redirected to stdout.  
@@ -21,3 +22,31 @@ where:
 - If sending to a forum chat, the `chat_id` in the configuration must start with `-100` followed by the chat ID.  
 - If sending to a group chat, the `chat_id` in the configuration should match the Telegram chat ID.  
 
+## How to Run
+
+### Bare Metal
+To run it on bare metal, first compile the binary:
+
+```sh
+go mod download
+go build -o tgnotify
+```
+
+Then run it with:
+
+```sh
+./tgnotify ping google.com
+```
+
+### Docker Compose
+You can also run it using Docker Compose:
+
+```sh
+docker compose up -d
+```
+
+Before doing that, make sure to specify the command you want to run in your `docker-compose.yml` file:
+
+```yml
+command: ["ping", "google.com"]
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.7"
+
+x-logging: &logging
+  logging:
+    driver: json-file
+    options:
+      max-size: 5m
+      max-file: "2"
+
+services:
+  tgnotify:
+    init: true
+    container_name: tgnotify
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    restart: no
+    environment:
+      - GOMAXPROCS=1
+    deploy:
+      resources:
+        limits:
+          memory: 0.1G
+          cpus: "1"
+    <<: *logging
+    networks:
+      - tgnotify_net
+    volumes:
+      - ./config.yml:/home/tgnotify/config.yml
+    command: ["ping", "google.com"]
+
+networks:
+  tgnotify_net: {}

--- a/main.go
+++ b/main.go
@@ -87,11 +87,11 @@ func main() {
 		cmdArgs []string
 		cmdProg string
 	)
-	notifyConfig := os.Getenv("NOTIFY_CONFIG")
-	if len(notifyConfig) == 0 {
-		log.Fatal().Msg("No config provided in NOTIFY_CONFIG")
+	notifyConfigPath := os.Getenv("NOTIFY_CONFIG")
+	if len(notifyConfigPath) == 0 {
+		notifyConfigPath = "/home/tgnotify/config.yml"
 	}
-	config := newConfig(notifyConfig)
+	config := newConfig(notifyConfigPath)
 	bot := newBot(config)
 
 	switch len(os.Args) {


### PR DESCRIPTION
In this PR, the `Dockerfile` and `docker-compose.yml` were added. Now the application can be easily run with Docker Compose.
Additionally, `notifyConfigPath` defaults to `/home/tgnotify/config.yml` if no environment variable is provided.